### PR TITLE
Add repository link

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT/Apache-2.0"
 description = """
 Macro to parse XML data into structs.
 """
+repository = "https://github.com/tcr/rust-fromxml"
 
 [lib]
 name = "fromxml"


### PR DESCRIPTION
It’s missing in https://crates.io/crates/fromxml
